### PR TITLE
Update CliqueMapillaryDataset.py for usability with later numpy versions

### DIFF
--- a/dataloaders/CliqueMapillaryDataset.py
+++ b/dataloaders/CliqueMapillaryDataset.py
@@ -180,7 +180,7 @@ def create_dataset_part(
 
                 # Append place to batch
                 rows = df.iloc[list(clique)]
-                images[i, batch_idx] = np.char.add(np.char.add(np.where(rows['query'].values, f'{city}/query/images/', f'{city}/database/images/').astype('<U100'), rows['key'].values), '.jpg')
+                images[i, batch_idx] = np.char.add(np.char.add(np.where(rows['query'].values, f'{city}/query/images/', f'{city}/database/images/').astype('<U100'), rows['key'].values.astype('<U100')), '.jpg')
                 batch_idx += 1
 
                 # Remove selected place and its neighbors from the graph


### PR DESCRIPTION
I made a small update to CliqueMapillaryDataset.py for usability with later numpy versions (>=1.26).
Otherwise when using e.g. numpy==1.26.4 it was throwing an error:
```
TypeError: np.char.add() requires both arrays of the same dtype kind, but got dtypes: '<U100' and 'object' (the few cases where this used to work often lead to incorrect results).
```
